### PR TITLE
Exponent sign parsing

### DIFF
--- a/Sources/Jay/NumberParser.swift
+++ b/Sources/Jay/NumberParser.swift
@@ -208,6 +208,17 @@ struct NumberParser: JsonParser {
         }
         try reader.nextAndCheckNotDone()
         
+        var sign = 1
+        //optionally there can be a sign: + or -
+        if Set<JChar>([Const.Plus, Const.Minus]).contains(reader.curr()) {
+            //found a sign, if it's plus, there's nothing to do,
+            //if it's minus, change out sign var
+            if reader.curr() == Const.Minus {
+                sign = -1
+            }
+            try reader.nextAndCheckNotDone()
+        }
+        
         var digs = [JChar]()
         
         //at least one digit 1...9 must follow
@@ -237,7 +248,7 @@ struct NumberParser: JsonParser {
             if expTerm.contains(reader.curr()) {
                 //gracefully end this section
                 let expString = try digs.string()
-                let exp = Int(expString)!
+                let exp = Int(expString)! * sign
                 return (exp, reader)
             }
             

--- a/Tests/ParsingTests.swift
+++ b/Tests/ParsingTests.swift
@@ -173,6 +173,18 @@ class ParsingTests: XCTestCase {
         ensureNumber(ret.0, exp: JsonNumber.JsonDbl(-2432.45))
     }
     
+    func testNumber_Double_Exp_Positive() {
+        let reader = ByteReader(content: "-24.3245e+2, ")
+        let ret = try! ValueParser().parse(withReader: reader)
+        ensureNumber(ret.0, exp: JsonNumber.JsonDbl(-2432.45))
+    }
+    
+    func testNumber_Double_Exp_Negative() {
+        let reader = ByteReader(content: "-24.3245e-2, ")
+        let ret = try! ValueParser().parse(withReader: reader)
+        ensureNumber(ret.0, exp: JsonNumber.JsonDbl(-0.243245))
+    }
+    
     func testNumber_Double_Exp_NoFrac() {
         let reader = ByteReader(content: "24E2, ")
         let ret = try! ValueParser().parse(withReader: reader)

--- a/Tests/TestUtils.swift
+++ b/Tests/TestUtils.swift
@@ -21,7 +21,18 @@ func ensureArray(val: JsonValue, exp: JsonArray) {
 }
 
 func ensureNumber(val: JsonValue, exp: JsonNumber) {
-    XCTAssertEqual(val, JsonValue.Number(exp))
+    switch val {
+    case .Number(let num):
+        
+        switch (num, exp) {
+        case (.JsonDbl(let l), .JsonDbl(let r)):
+            XCTAssertEqualWithAccuracy(r, l, accuracy: 1e-10)
+        case (.JsonInt(let l), .JsonInt(let r)):
+            XCTAssertEqual(l, r)
+        default: XCTFail()
+        }
+    default: XCTFail()
+    }
 }
 
 func ensureString(val: JsonValue, exp: JsonString) {


### PR DESCRIPTION
Fixed missing parsing code for the number exponent optional sign (e.g 12e+3, 15e-8)
