### PR TITLE
Easier serialization for Linux

### DIFF
--- a/Sources/Jay/Jay.swift
+++ b/Sources/Jay/Jay.swift
@@ -21,7 +21,23 @@ public struct Jay {
     }
     
     //Formats your JSON-compatible object into data or throws an error.
+    public func dataFromJson(json: JSON) throws -> [UInt8] {
+        return try self.dataFromAnyJson(json.json)
+    }
+
+    public func dataFromJson(json: [String: Any]) throws -> [UInt8] {
+        return try self.dataFromAnyJson(json)
+    }
+
+    public func dataFromJson(json: [Any]) throws -> [UInt8] {
+        return try self.dataFromAnyJson(json)
+    }
+    
     public func dataFromJson(json: Any) throws -> [UInt8] {
+        return try self.dataFromAnyJson(json)
+    }
+
+    private func dataFromAnyJson(json: Any) throws -> [UInt8] {
         
         let jayType = try NativeTypeConverter().toJayType(json)
         let data = try jayType.format()

--- a/Sources/Jay/Jay.swift
+++ b/Sources/Jay/Jay.swift
@@ -21,7 +21,8 @@ public struct Jay {
     }
     
     //Formats your JSON-compatible object into data or throws an error.
-    public func dataFromJson(json: Any) throws -> [UInt8] {
+
+    public func dataFromJson(json: JaySON) throws -> [UInt8] {
         
         let jayType = try NativeTypeConverter().toJayType(json)
         let data = try jayType.format()

--- a/Sources/Jay/Jay.swift
+++ b/Sources/Jay/Jay.swift
@@ -21,8 +21,7 @@ public struct Jay {
     }
     
     //Formats your JSON-compatible object into data or throws an error.
-
-    public func dataFromJson(json: JaySON) throws -> [UInt8] {
+    public func dataFromJson(json: Any) throws -> [UInt8] {
         
         let jayType = try NativeTypeConverter().toJayType(json)
         let data = try jayType.format()

--- a/Sources/Jay/NativeTypeConversions.swift
+++ b/Sources/Jay/NativeTypeConversions.swift
@@ -11,8 +11,8 @@ import Foundation
 public protocol JaySON {}
 extension NSArray: JaySON {}
 extension NSDictionary: JaySON {}
-extension Dictionary where Generator.Element == (String, Any): JaySON {}
-extension Array where Generator.Element == Any: JaySON {}
+extension Dictionary: JaySON {}
+extension Array: JaySON {}
 
 extension JsonValue {
 

--- a/Sources/Jay/NativeTypeConversions.swift
+++ b/Sources/Jay/NativeTypeConversions.swift
@@ -80,6 +80,9 @@ struct NativeTypeConverter {
     
     func arrayToJayType(maybeArray: Any) throws -> JsonValue? {
         
+        let mirror = Mirror(reflecting: maybeArray)
+        print(mirror)
+        
         switch maybeArray {
             
         case let a as [Any]: return try self.convertArray(a)
@@ -105,6 +108,9 @@ struct NativeTypeConverter {
     }
     
     func dictionaryToJayType(maybeDictionary: Any) throws -> JsonValue? {
+        
+        let mirror = Mirror(reflecting: maybeDictionary)
+        print(mirror)
         
         switch maybeDictionary {
             

--- a/Sources/Jay/NativeTypeConversions.swift
+++ b/Sources/Jay/NativeTypeConversions.swift
@@ -13,6 +13,7 @@ extension NSArray: JaySON {}
 extension NSDictionary: JaySON {}
 extension Dictionary: JaySON {}
 extension Array: JaySON {}
+extension DictionaryLiteral: JaySON {}
 
 extension JsonValue {
 

--- a/Sources/Jay/NativeTypeConversions.swift
+++ b/Sources/Jay/NativeTypeConversions.swift
@@ -95,6 +95,7 @@ struct NativeTypeConverter {
             
             //whenever bridging works properly, we can just keep the above [Any]
             
+        case let a as [AnyObject]: return try self.convertArray(a)
         case let a as [String]: return try self.convertArray(a)
         case let a as [Double]: return try self.convertArray(a)
         case let a as [Float]: return try self.convertArray(a)
@@ -124,6 +125,7 @@ struct NativeTypeConverter {
         case let d as [String: Any]: return try self.convertDict(d)
             
             //whenever bridging works properly, we can just keep the above [Any]
+        case let d as [String: AnyObject]: return try self.convertDict(d)
         case let d as [String: String]: return try self.convertDict(d)
         case let d as [String: Double]: return try self.convertDict(d)
         case let d as [String: Float]: return try self.convertDict(d)
@@ -173,6 +175,13 @@ struct NativeTypeConverter {
                 throw Error.UnsupportedIntegerType(int)
             }
             return JsonValue.Number(JsonNumber.JsonInt(integer))
+        case let num as NSNumber:
+            //if the double value equals the int->double value, let's call it
+            //an int. otherwise call it a value.
+            if Double(num.intValue) == num.doubleValue {
+                return JsonValue.Number(JsonNumber.JsonInt(Int(num.intValue)))
+            }
+            return JsonValue.Number(JsonNumber.JsonDbl(num.doubleValue))
             
         //string (or anything representable as string that didn't match above)
         case let string as String:

--- a/Sources/Jay/NativeTypeConversions.swift
+++ b/Sources/Jay/NativeTypeConversions.swift
@@ -8,13 +8,6 @@
 
 import Foundation
 
-public protocol JaySON {}
-extension NSArray: JaySON {}
-extension NSDictionary: JaySON {}
-extension Dictionary: JaySON {}
-extension Array: JaySON {}
-extension DictionaryLiteral: JaySON {}
-
 extension JsonValue {
 
     func toNative() -> Any {

--- a/Sources/Jay/NativeTypeConversions.swift
+++ b/Sources/Jay/NativeTypeConversions.swift
@@ -100,6 +100,7 @@ struct NativeTypeConverter {
         case let a as [NSNumber]: return try self.convertArray(a)
         case let a as [NSString]: return try self.convertArray(a)
         case let a as [NSNull]: return try self.convertArray(a)
+        case let a as [NSObject]: return try self.convertArray(a)
 
         case let a as NSArray: return try self.parseNSArray(a)
             
@@ -128,6 +129,7 @@ struct NativeTypeConverter {
         case let d as [String: NSNumber]: return try self.convertDict(d)
         case let d as [String: NSString]: return try self.convertDict(d)
         case let d as [String: NSNull]: return try self.convertDict(d)
+        case let d as [String: NSObject]: return try self.convertDict(d)
 
         case let d as NSDictionary: return try self.parseNSDictionary(d)
 

--- a/Sources/Jay/NativeTypeConversions.swift
+++ b/Sources/Jay/NativeTypeConversions.swift
@@ -8,6 +8,17 @@
 
 import Foundation
 
+public struct JSON {
+    public let json: Any
+}
+
+extension JSON {
+    public init(_ dict: NSDictionary) { self.json = dict }
+    public init(_ array: NSArray) { self.json = array }
+    public init(_ dict: [String: Any]) { self.json = dict }
+    public init(_ array: [Any]) { self.json = array }
+}
+
 extension JsonValue {
 
     func toNative() -> Any {
@@ -80,9 +91,6 @@ struct NativeTypeConverter {
     
     func arrayToJayType(maybeArray: Any) throws -> JsonValue? {
         
-        let mirror = Mirror(reflecting: maybeArray)
-        print(mirror)
-        
         switch maybeArray {
             
         case let a as [Any]: return try self.convertArray(a)
@@ -110,9 +118,6 @@ struct NativeTypeConverter {
     }
     
     func dictionaryToJayType(maybeDictionary: Any) throws -> JsonValue? {
-        
-        let mirror = Mirror(reflecting: maybeDictionary)
-        print(mirror)
         
         switch maybeDictionary {
             
@@ -186,7 +191,7 @@ struct NativeTypeConverter {
         default: break
         }
         //nothing matched
-        throw Error.UnsupportedType(json)
+        throw Error.UnsupportedType("\(Mirror(reflecting: json))")
     }
 }
 

--- a/Sources/Jay/NativeTypeConversions.swift
+++ b/Sources/Jay/NativeTypeConversions.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+public protocol JaySON {}
+extension NSArray: JaySON {}
+extension NSDictionary: JaySON {}
+extension Dictionary where Generator.Element == (String, Any): JaySON {}
+extension Array where Generator.Element == Any: JaySON {}
+
 extension JsonValue {
 
     func toNative() -> Any {

--- a/Tests/Jay/FormattingTests.swift
+++ b/Tests/Jay/FormattingTests.swift
@@ -145,4 +145,22 @@ class FormattingTests: XCTestCase {
         XCTAssertEqual(data, "[\"he \\r\\n l \\t l \\n o w\\\"o\\rrld \"]".chars())
     }
     
+    func testVaporExample() {
+        
+        let data = try! Jay().dataFromJson(
+            [
+                "number": 123,
+                "string": "test",
+                "array": [
+                    0, 1, 2, 3
+                ],
+                "dict": [
+                    "name": "Vapor",
+                    "lang": "Swift"
+                ]
+            ]
+        )
+        XCTAssertEqual(data, "".chars())
+    }
+    
 }

--- a/Tests/Jay/FormattingTests.swift
+++ b/Tests/Jay/FormattingTests.swift
@@ -146,7 +146,7 @@ class FormattingTests: XCTestCase {
         XCTAssertEqual(data, "[\"he \\r\\n l \\t l \\n o w\\\"o\\rrld \"]".chars())
     }
     
-    func takeJson(json: JaySON) -> JaySON {
+    func takeJson(json: [String: Any]) -> JaySON {
         return json
     }
     

--- a/Tests/Jay/FormattingTests.swift
+++ b/Tests/Jay/FormattingTests.swift
@@ -146,13 +146,9 @@ class FormattingTests: XCTestCase {
         XCTAssertEqual(data, "[\"he \\r\\n l \\t l \\n o w\\\"o\\rrld \"]".chars())
     }
     
-    func takeJson(json: [String: Any]) -> Any {
-        return json
-    }
-    
-    func testVaporExample() {
+    func testVaporExample_Dict() {
         
-        let json = self.takeJson(
+        let json = JSON(
             [
                 "number": 123,
                 "string": "test",
@@ -169,5 +165,28 @@ class FormattingTests: XCTestCase {
         let exp = "{\"array\":[0,1,2,3],\"dict\":{\"lang\":\"Swift\",\"name\":\"Vapor\"},\"number\":123,\"string\":\"test\"}"
         XCTAssertEqual(data, exp.chars(), "Expected: \n\(exp)\ngot\n\(try! data.string())\n")
     }
+    
+    func testVaporExample_Array() {
+        
+        let json = JSON(
+            [
+                "number",
+                123,
+                "string",
+                "test",
+                "array",
+                [0, 1, 2, 3],
+                "dict",
+                [
+                    "name": "Vapor",
+                    "lang": "Swift"
+                ]
+            ]
+        )
+        let data = try! Jay().dataFromJson(json)
+        let exp = "[\"number\",123,\"string\",\"test\",\"array\",[0,1,2,3],\"dict\",{\"lang\":\"Swift\",\"name\":\"Vapor\"}]"
+        XCTAssertEqual(data, exp.chars(), "Expected: \n\(exp)\ngot\n\(try! data.string())\n")
+    }
+
     
 }

--- a/Tests/Jay/FormattingTests.swift
+++ b/Tests/Jay/FormattingTests.swift
@@ -146,7 +146,7 @@ class FormattingTests: XCTestCase {
         XCTAssertEqual(data, "[\"he \\r\\n l \\t l \\n o w\\\"o\\rrld \"]".chars())
     }
     
-    func takeJson(json: [String: Any]) -> JaySON {
+    func takeJson(json: [String: Any]) -> Any {
         return json
     }
     

--- a/Tests/Jay/FormattingTests.swift
+++ b/Tests/Jay/FormattingTests.swift
@@ -146,19 +146,25 @@ class FormattingTests: XCTestCase {
         XCTAssertEqual(data, "[\"he \\r\\n l \\t l \\n o w\\\"o\\rrld \"]".chars())
     }
     
+    func takeJson(json: JaySON) -> JaySON {
+        return json
+    }
+    
     func testVaporExample() {
-
-        let json: [String: Any] = [
-            "number": 123,
-            "string": "test",
-            "array": [
-                0, 1, 2, 3
-            ],
-            "dict": [
-                "name": "Vapor",
-                "lang": "Swift"
+        
+        let json = self.takeJson(
+            [
+                "number": 123,
+                "string": "test",
+                "array": [
+                    0, 1, 2, 3
+                ],
+                "dict": [
+                    "name": "Vapor",
+                    "lang": "Swift"
+                ]
             ]
-        ]
+        )
         let data = try! Jay().dataFromJson(json)
         let exp = "{\"array\":[0,1,2,3],\"dict\":{\"lang\":\"Swift\",\"name\":\"Vapor\"},\"number\":123,\"string\":\"test\"}"
         XCTAssertEqual(data, exp.chars(), "Expected: \n\(exp)\ngot\n\(try! data.string())\n")

--- a/Tests/Jay/FormattingTests.swift
+++ b/Tests/Jay/FormattingTests.swift
@@ -160,7 +160,7 @@ class FormattingTests: XCTestCase {
                 ]
             ]
         )
-        XCTAssertEqual(data, "".chars())
+        XCTAssertEqual(data, "{\"array\":[0.0,1.0,2.0,3.0],\"dict\":{\"lang\":\"Swift\",\"name\":\"Vapor\"},\"number\":\"123\",\"string\":\"test\"}".chars())
     }
     
 }

--- a/Tests/Jay/FormattingTests.swift
+++ b/Tests/Jay/FormattingTests.swift
@@ -26,7 +26,8 @@ import Foundation
                 ("testArray_Simple", testArray_Simple),
                 ("testArray_Nested", testArray_Nested),
                 ("testNSArray_Simple", testNSArray_Simple),
-                ("testString_Escaping", testString_Escaping)
+                ("testString_Escaping", testString_Escaping),
+                ("testVaporExample", testVaporExample)
             ]
         }
     }

--- a/Tests/Jay/FormattingTests.swift
+++ b/Tests/Jay/FormattingTests.swift
@@ -27,7 +27,8 @@ import Foundation
                 ("testArray_Nested", testArray_Nested),
                 ("testNSArray_Simple", testNSArray_Simple),
                 ("testString_Escaping", testString_Escaping),
-                ("testVaporExample", testVaporExample)
+                ("testVaporExample_Dict", testVaporExample_Dict),
+                ("testVaporExample_Array", testVaporExample_Array)
             ]
         }
     }

--- a/Tests/Jay/FormattingTests.swift
+++ b/Tests/Jay/FormattingTests.swift
@@ -147,21 +147,21 @@ class FormattingTests: XCTestCase {
     }
     
     func testVaporExample() {
-        
-        let data = try! Jay().dataFromJson(
-            [
-                "number": 123,
-                "string": "test",
-                "array": [
-                    0, 1, 2, 3
-                ],
-                "dict": [
-                    "name": "Vapor",
-                    "lang": "Swift"
-                ]
+
+        let json: [String: Any] = [
+            "number": 123,
+            "string": "test",
+            "array": [
+                0, 1, 2, 3
+            ],
+            "dict": [
+                "name": "Vapor",
+                "lang": "Swift"
             ]
-        )
-        XCTAssertEqual(data, "{\"array\":[0.0,1.0,2.0,3.0],\"dict\":{\"lang\":\"Swift\",\"name\":\"Vapor\"},\"number\":\"123\",\"string\":\"test\"}".chars())
+        ]
+        let data = try! Jay().dataFromJson(json)
+        let exp = "{\"array\":[0,1,2,3],\"dict\":{\"lang\":\"Swift\",\"name\":\"Vapor\"},\"number\":123,\"string\":\"test\"}"
+        XCTAssertEqual(data, exp.chars(), "Expected: \n\(exp)\ngot\n\(try! data.string())\n")
     }
     
 }

--- a/XcodeProject/Jay.xcodeproj/xcshareddata/xcbaselines/3AFC690E1C74EE4100BC8E73.xcbaseline/3EF43033-E35F-458E-A1BB-76ECDC3E5C95.plist
+++ b/XcodeProject/Jay.xcodeproj/xcshareddata/xcbaselines/3AFC690E1C74EE4100BC8E73.xcbaseline/3EF43033-E35F-458E-A1BB-76ECDC3E5C95.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.676</real>
+					<real>0.847</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 					<key>maxPercentRelativeStandardDeviation</key>


### PR DESCRIPTION
To get around the lack of proper inference and bridging on Linux, this way you can just create a `JSON` object, which can also be passed to Jay. This makes it easier to use dictionary/array literals on Linux.

Partially related to #8.
