### PR TITLE
Added streaming output

### DIFF
--- a/Sources/Jay/Jay.swift
+++ b/Sources/Jay/Jay.swift
@@ -37,24 +37,46 @@ public struct Jay {
     public func dataFromJson(_ json: JaySON) throws -> [UInt8] {
         return try self.dataFromAnyJson(json.json)
     }
+    
+    public func dataFromJson(_ json: JaySON, output: JsonOutputStream) throws {
+        try self.dataFromAnyJson(json.json, output: output)
+    }
 
     public func dataFromJson(_ json: [String: Any]) throws -> [UInt8] {
         return try self.dataFromAnyJson(json)
     }
 
+    public func dataFromJson(_ json: [String: Any], output: JsonOutputStream) throws {
+        try self.dataFromAnyJson(json, output: output)
+    }
+
     public func dataFromJson(_ json: [Any]) throws -> [UInt8] {
         return try self.dataFromAnyJson(json)
     }
-    
+
+    public func dataFromJson(_ json: [Any], output: JsonOutputStream) throws {
+        try self.dataFromAnyJson(json, output: output)
+    }
+
     public func dataFromJson(_ json: Any) throws -> [UInt8] {
         return try self.dataFromAnyJson(json)
     }
 
+    public func dataFromJson(_ json: Any, output: JsonOutputStream) throws {
+        try self.dataFromAnyJson(json, output: output)
+    }
+
     private func dataFromAnyJson(_ json: Any) throws -> [UInt8] {
         
+        let output = ByteArrayOutputStream()
+        try dataFromAnyJson(json, output: output)
+        return output.bytes
+    }
+    
+    func dataFromAnyJson(_ json: Any, output: JsonOutputStream) throws {
+        
         let jayType = try NativeTypeConverter().toJayType(json)
-        let data = try jayType.format(with: formatting.formatter())
-        return data
+        try jayType.format(to: output, with: formatting.formatter())
     }
 }
 
@@ -113,7 +135,13 @@ extension Jay {
 
     //Formats your JSON-compatible object into data or throws an error.
     public func dataFromJson(json: JsonValue) throws -> [UInt8] {
-        return try json.format(with: formatting.formatter())
+        let output = ByteArrayOutputStream()
+        try dataFromJson(json: json, output: output)
+        return output.bytes
+    }
+    
+    public func dataFromJson(json: JsonValue, output: JsonOutputStream) throws {
+        try json.format(to: output, with: formatting.formatter())
     }
 }
 

--- a/Sources/Jay/OutputStream.swift
+++ b/Sources/Jay/OutputStream.swift
@@ -1,0 +1,48 @@
+//
+//  OutputStream.swift
+//  Jay
+//
+//  Created by Honza Dvorsky on 5/21/16.
+//
+//
+
+public protocol JsonOutputStream {
+    func print(_ bytes: [UInt8])
+}
+
+infix operator <<< { associativity left }
+
+@discardableResult
+func <<<(stream: JsonOutputStream, value: UInt8) -> JsonOutputStream {
+    stream.print([value])
+    return stream
+}
+
+@discardableResult
+func <<<(stream: JsonOutputStream, value: [UInt8]) -> JsonOutputStream {
+    stream.print(value)
+    return stream
+}
+
+public class ConsoleOutputStream: JsonOutputStream {
+    
+    public init() { }
+
+    public func print(_ bytes: [UInt8]) {
+        let str = try? bytes.string()
+        Swift.print(str ?? "UNFORMATTABLE DATA", terminator: "")
+    }
+}
+
+public class ByteArrayOutputStream: JsonOutputStream {
+    
+    public var bytes: [UInt8]
+    
+    public init() {
+        self.bytes = []
+    }
+    
+    public func print(_ bytes: [UInt8]) {
+        self.bytes += bytes
+    }
+}

--- a/Sources/JayExample/main.swift
+++ b/Sources/JayExample/main.swift
@@ -54,9 +54,33 @@ func tryFormatting() {
     print("Formatting works:")
 }
 
+func tryFormattingToConsole() {
+    
+    let inObj: [String: Any] = ["hola": 9.23, "nums": [1,2,3]]
+    let obj: [String: Any] = [
+                                 "hello": "wor🇨🇿ld",
+                                 "val": 1234,
+                                 "many": [
+                                             -12.32,
+                                             NSNull(),
+                                             "yo",
+                                             inObj
+                                    ] as [Any],
+                                 "emptyDict": [String: Any](),
+                                 "dict": [
+                                             "arr": [Int]()
+                                    ] as [String: Any],
+                                 "name": true
+    ]
+    
+    let output = ConsoleOutputStream()
+    print("Dumping to console:")
+    try! Jay(formatting: .prettified).dataFromJson(obj, output: output)
+}
+
 tryFormatting()
 tryParsing()
-
+tryFormattingToConsole()
 
 
 


### PR DESCRIPTION
Now you can also ask for data now just returned as a byte array, but you can provide a stream into which the data is written by chunks. This can be useful if you're working with rather large structures that you want to e.g. send over the network, send to disk, print to the console etc.
