### PR TITLE
Added support for JSON comments

### DIFF
--- a/Sources/Jay/ArrayParser.swift
+++ b/Sources/Jay/ArrayParser.swift
@@ -8,6 +8,8 @@
 
 struct ArrayParser: JsonParser {
     
+    var parsing: Jay.ParsingOptions
+
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
         try prepareForReading(with: reader)
@@ -30,10 +32,11 @@ struct ArrayParser: JsonParser {
         
         //now start scanning for values
         var values = [JSON]()
+        let valueParser = ValueParser(parsing: parsing)
         repeat {
             
             //scan for value
-            let ret = try ValueParser().parse(with: reader)
+            let ret = try valueParser.parse(with: reader)
             values.append(ret)
             
             //scan for either a comma, in which case there must be another

--- a/Sources/Jay/ArrayParser.swift
+++ b/Sources/Jay/ArrayParser.swift
@@ -10,7 +10,7 @@ struct ArrayParser: JsonParser {
     
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
         
         //detect opening bracket
         guard reader.curr() == Const.BeginArray else {
@@ -19,7 +19,7 @@ struct ArrayParser: JsonParser {
         try reader.nextAndCheckNotDone()
         
         //move along, now start looking for values
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
         
         //check curr value for closing bracket, to handle empty array
         if reader.curr() == Const.EndArray {
@@ -38,7 +38,7 @@ struct ArrayParser: JsonParser {
             
             //scan for either a comma, in which case there must be another
             //value OR for a closing bracket
-            try self.prepareForReading(with: reader)
+            try prepareForReading(with: reader)
             switch reader.curr() {
             case Const.EndArray: try reader.next(); return .array(values)
             case Const.ValueSeparator: try reader.next(); break //comma, so another value must come. let the loop repeat.

--- a/Sources/Jay/BooleanParser.swift
+++ b/Sources/Jay/BooleanParser.swift
@@ -22,7 +22,7 @@ struct BooleanParser: JsonParser {
             return .boolean(false)
         }
         
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
         
         //find whether we're parsing "true" or "false"
         let char = reader.curr()

--- a/Sources/Jay/BooleanParser.swift
+++ b/Sources/Jay/BooleanParser.swift
@@ -8,6 +8,8 @@
 
 struct BooleanParser: JsonParser {
     
+    var parsing: Jay.ParsingOptions
+
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
         func parseTrue<R: Reader>(_ reader: R) throws -> JSON {

--- a/Sources/Jay/CommentParser.swift
+++ b/Sources/Jay/CommentParser.swift
@@ -1,0 +1,68 @@
+struct CommentParser {
+    
+    func parse<R: Reader>(with reader: R) throws -> [JChar] {
+        
+        //ensure we're starting with a slash
+        guard reader.curr() == Const.Solidus else {
+            throw JayError.unexpectedCharacter(reader)
+        }
+        try reader.nextAndCheckNotDone()
+        
+        switch reader.curr() {
+            
+            //if another slash, it's a single-line comment
+        case Const.Solidus:
+            return try SingleLineCommentParser().parse(with: reader)
+            
+            //if a star, it's the beginning of a multi-line comment
+        case Const.Star:
+            return try MultiLineCommentParser().parse(with: reader)
+            
+            //if anything else, syntax error
+        default:
+            throw JayError.unexpectedCharacter(reader)
+        }
+    }
+}
+
+struct SingleLineCommentParser {
+    
+    func parse<R: Reader>(with reader: R) throws -> [JChar] {
+        
+        //single line comment starts with "//" and ends with "\n"
+        //everything in between is a part of the comment string
+        
+        //move after the second slash
+        try reader.nextAndCheckNotDone()
+        
+        //keep seeking until we find "\n", then terminate and return everything between
+        let end = [Const.NewLine]
+        let (collected, _) = try reader.collectUntil(terminator: end)
+        
+        //here we don't actually care if we don't find the terminator, it just means
+        //the user didn't end their file with a newline
+        return collected
+    }
+}
+
+struct MultiLineCommentParser {
+    
+    func parse<R: Reader>(with reader: R) throws -> [JChar] {
+
+        //multi line comment starts with "/*" and ends with "*/"
+        //pretty simple!
+        
+        //move after the star slash
+        try reader.nextAndCheckNotDone()
+
+        //keep seeking until we find "\n", then terminate and return everything between
+        let end = [Const.Star, Const.Solidus]
+        let (collected, foundTerminator) = try reader.collectUntil(terminator: end)
+        
+        //multi-line comment must be terminated
+        guard foundTerminator else {
+            throw JayError.unterminatedComment(reader)
+        }
+        return collected
+    }
+}

--- a/Sources/Jay/CommentParser.swift
+++ b/Sources/Jay/CommentParser.swift
@@ -1,5 +1,5 @@
 struct CommentParser {
-    
+        
     func parse<R: Reader>(with reader: R) throws -> [JChar] {
         
         //ensure we're starting with a slash

--- a/Sources/Jay/Consts.swift
+++ b/Sources/Jay/Consts.swift
@@ -56,6 +56,7 @@ struct Const {
     static let QuotationMark: JChar         = 0x22 // """
     static let ReverseSolidus: JChar        = 0x5c // "\"
     static let Solidus: JChar               = 0x2f // "/"
+    static let Star: JChar                  = 0x2a // "*"
 
     static let BackspaceChar: JChar         = 0x62 // "b"
     static let HorizontalTabChar: JChar     = 0x74 // "t"
@@ -111,6 +112,7 @@ struct StartChars {
     static let String: Set<JChar>   = [Const.QuotationMark]
     static let Boolean: Set<JChar>  = [Const.False[0], Const.True[0]]
     static let Null: Set<JChar>     = [Const.Null[0]]
+    static let Comment: Set<JChar>  = [Const.Solidus]
 }
 
 

--- a/Sources/Jay/Error.swift
+++ b/Sources/Jay/Error.swift
@@ -26,5 +26,6 @@ enum JayError: Swift.Error {
     case keyIsNotString(Any)
     case extraTokensFound(Reader)
     case invalidUnicodeScalar(UInt16)
+    case unterminatedComment(Reader)
 }
 

--- a/Sources/Jay/Jay.swift
+++ b/Sources/Jay/Jay.swift
@@ -15,14 +15,33 @@ public struct Jay {
         case minified
         case prettified
     }
+    
+    public struct ParsingOptions: OptionSet {
+        public let rawValue: Int
+        
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+        
+        static let none = ParsingOptions(rawValue: 0)
+        
+        /// Allows single line (starting //) or multi-line (/* ... */) comments,
+        /// strips them out during parsing.
+        static let allowComments = ParsingOptions(rawValue: 1 << 0)
+    }
   
     /// The formatting used.
     public let formatting: Formatting
+    
+    /// Parsing options
+    public let parsing: ParsingOptions
   
     /// Initializes and returns the `Jay` object.
     /// - Parameter formatting: The `Formatting` to use. Defaults to `.minified`.
-    public init(formatting: Formatting = .minified) {
+    /// - Parameter parsing: The `ParsingOptions` to use. Defaults to `.none`.
+    public init(formatting: Formatting = .minified, parsing: ParsingOptions = .none) {
         self.formatting = formatting
+        self.parsing = parsing
     }
     
     /// Parses data into a dictionary `[String: Any]` or array `[Any]`.
@@ -30,13 +49,13 @@ public struct Jay {
     /// casting whether you received what you expected.
     /// - Throws: A descriptive error in case of any problem.
     public func anyJsonFromData(_ data: [UInt8]) throws -> Any {
-        return try NativeParser().parse(data)
+        return try NativeParser(options: parsing).parse(data)
     }
   
     /// Parses the reader to `Any`.
     /// - Throws: A descriptive error in case of any problem.
     public func anyJsonFromReader<R: Reader>(_ reader: R) throws -> Any {
-        return try NativeParser().parse(reader)
+        return try NativeParser(options: parsing).parse(reader)
     }
     
     /// Formats your JSON-compatible object into data.
@@ -146,7 +165,7 @@ extension Jay {
     /// - SeeAlso: If you just want Swift types with less
     /// type-information, use `jsonFromData()` above.
     public func jsonFromData(_ data: [UInt8]) throws -> JSON {
-        return try Parser().parseJsonFromData(data)
+        return try Parser(parsing: parsing).parseJsonFromData(data)
     }
   
     /// Allows users to get the `JSON` representation in a typesafe matter.
@@ -155,7 +174,7 @@ extension Jay {
     /// - SeeAlso: If you just want Swift types with less
     /// type-information, use `jsonFromReader()` above.
     public func jsonFromReader<R: Reader>(_ reader: R) throws -> JSON {
-        return try Parser().parseJsonFromReader(reader)
+        return try Parser(parsing: parsing).parseJsonFromReader(reader)
     }
 
     /// Formats your JSON-compatible object into data.

--- a/Sources/Jay/NativeParser.swift
+++ b/Sources/Jay/NativeParser.swift
@@ -10,12 +10,14 @@
 
 struct NativeParser {
     
+    let options: Jay.ParsingOptions
+    
     func parse(_ data: [UInt8]) throws -> Any {
-        return _postProcess(try Parser().parseJsonFromData(data))
+        return _postProcess(try Parser(parsing: options).parseJsonFromData(data))
     }
     
     func parse<R: Reader>(_ reader: R) throws -> Any {
-        return _postProcess(try Parser().parseJsonFromReader(reader))
+        return _postProcess(try Parser(parsing: options).parseJsonFromReader(reader))
     }
     
     private func _postProcess(_ jsonValue: JSON) -> Any {

--- a/Sources/Jay/NullParser.swift
+++ b/Sources/Jay/NullParser.swift
@@ -8,6 +8,8 @@
 
 struct NullParser: JsonParser {
     
+    var parsing: Jay.ParsingOptions
+
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
         try prepareForReading(with: reader)

--- a/Sources/Jay/NullParser.swift
+++ b/Sources/Jay/NullParser.swift
@@ -10,7 +10,7 @@ struct NullParser: JsonParser {
     
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
         
         //try to read the "null" literal, throw if anything goes wrong
         try reader.stopAtFirstDifference(ByteReader(content: Const.Null))

--- a/Sources/Jay/NumberParser.swift
+++ b/Sources/Jay/NumberParser.swift
@@ -14,6 +14,8 @@
 
 struct NumberParser: JsonParser {
     
+    var parsing: Jay.ParsingOptions
+
     //phase    1         2   3        4
     //number = [ minus ] int [ frac ] [ exp ]
     //exp = e [ minus / plus ] 1*DIGIT

--- a/Sources/Jay/NumberParser.swift
+++ b/Sources/Jay/NumberParser.swift
@@ -22,7 +22,7 @@ struct NumberParser: JsonParser {
     
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
         
         //1. Optional minus
         let negative = try self.parseMinus(reader)

--- a/Sources/Jay/ObjectParser.swift
+++ b/Sources/Jay/ObjectParser.swift
@@ -10,7 +10,7 @@ struct ObjectParser: JsonParser {
     
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
         
         //detect opening brace
         guard reader.curr() == Const.BeginObject else {
@@ -19,7 +19,7 @@ struct ObjectParser: JsonParser {
         try reader.nextAndCheckNotDone()
         
         //move along, now start looking for name/value pairs
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
 
         //check curr value for closing bracket, to handle empty object
         if reader.curr() == Const.EndObject {
@@ -43,7 +43,7 @@ struct ObjectParser: JsonParser {
             }
             
             //scan for name separator :
-            try self.prepareForReading(with: reader)
+            try prepareForReading(with: reader)
             guard reader.curr() == Const.NameSeparator else {
                 throw JayError.objectNameSeparatorMissing(reader)
             }
@@ -58,7 +58,7 @@ struct ObjectParser: JsonParser {
             
             //scan for either a comma, in which case there must be another
             //value OR for a closing brace
-            try self.prepareForReading(with: reader)
+            try prepareForReading(with: reader)
             switch reader.curr() {
             case Const.EndObject:
                 try reader.next()

--- a/Sources/Jay/ObjectParser.swift
+++ b/Sources/Jay/ObjectParser.swift
@@ -8,6 +8,8 @@
 
 struct ObjectParser: JsonParser {
     
+    var parsing: Jay.ParsingOptions
+
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
         try prepareForReading(with: reader)
@@ -30,8 +32,8 @@ struct ObjectParser: JsonParser {
 
         //now start scanning for name/value pairs
         var pairs = [(String, JSON)]()
-        let stringParser = StringParser()
-        let valueParser = ValueParser()
+        let stringParser = StringParser(parsing: parsing)
+        let valueParser = ValueParser(parsing: parsing)
         repeat {
             
             //scan for name

--- a/Sources/Jay/RootParser.swift
+++ b/Sources/Jay/RootParser.swift
@@ -10,7 +10,7 @@ struct RootParser: JsonParser {
     
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
         
         //the standard doesn't require handling of fragments, so here
         //we'll assume we're only parsing valid structured types (object/array)

--- a/Sources/Jay/RootParser.swift
+++ b/Sources/Jay/RootParser.swift
@@ -8,6 +8,8 @@
 
 struct RootParser: JsonParser {
     
+    var parsing: Jay.ParsingOptions
+
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
         try prepareForReading(with: reader)
@@ -17,9 +19,9 @@ struct RootParser: JsonParser {
         let root: JSON
         switch reader.curr() {
         case Const.BeginObject:
-            root = try ObjectParser().parse(with: reader)
+            root = try ObjectParser(parsing: parsing).parse(with: reader)
         case Const.BeginArray:
-            root = try ArrayParser().parse(with: reader)
+            root = try ArrayParser(parsing: parsing).parse(with: reader)
         default:
             throw JayError.unimplemented("ParseRoot")
         }

--- a/Sources/Jay/StringParser.swift
+++ b/Sources/Jay/StringParser.swift
@@ -14,6 +14,8 @@
 
 struct StringParser: JsonParser {
     
+    var parsing: Jay.ParsingOptions
+
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
         try prepareForReading(with: reader)

--- a/Sources/Jay/StringParser.swift
+++ b/Sources/Jay/StringParser.swift
@@ -16,7 +16,7 @@ struct StringParser: JsonParser {
     
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
         
         //ensure we're starting with a quote
         guard reader.curr() == Const.QuotationMark else {

--- a/Sources/Jay/ValueParser.swift
+++ b/Sources/Jay/ValueParser.swift
@@ -6,32 +6,27 @@
 //  Copyright © 2016 Honza Dvorsky. All rights reserved.
 //
 
-private let objectParser = ObjectParser()
-private let stringParser = StringParser()
-private let arrayParser = ArrayParser()
-private let numberParser = NumberParser()
-private let booleanParser = BooleanParser()
-private let nullParser = NullParser()
-
 struct ValueParser: JsonParser {
     
+    var parsing: Jay.ParsingOptions
+
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
         try prepareForReading(with: reader)
         
         switch reader.curr() {
         case let x where StartChars.Object.contains(x):
-            return try objectParser.parse(with: reader)
+            return try ObjectParser(parsing: parsing).parse(with: reader)
         case let x where StartChars.Array.contains(x):
-            return try arrayParser.parse(with: reader)
+            return try ArrayParser(parsing: parsing).parse(with: reader)
         case let x where StartChars.Number.contains(x):
-            return try numberParser.parse(with: reader)
+            return try NumberParser(parsing: parsing).parse(with: reader)
         case let x where StartChars.String.contains(x):
-            return try stringParser.parse(with: reader)
+            return try StringParser(parsing: parsing).parse(with: reader)
         case let x where StartChars.Boolean.contains(x):
-            return try booleanParser.parse(with: reader)
+            return try BooleanParser(parsing: parsing).parse(with: reader)
         case let x where StartChars.Null.contains(x):
-            return try nullParser.parse(with: reader)
+            return try NullParser(parsing: parsing).parse(with: reader)
         default:
             throw JayError.unexpectedCharacter(reader)
         }

--- a/Sources/Jay/ValueParser.swift
+++ b/Sources/Jay/ValueParser.swift
@@ -17,7 +17,7 @@ struct ValueParser: JsonParser {
     
     func parse<R: Reader>(with reader: R) throws -> JSON {
         
-        try self.prepareForReading(with: reader)
+        try prepareForReading(with: reader)
         
         switch reader.curr() {
         case let x where StartChars.Object.contains(x):

--- a/Tests/JayTests/Fixtures/withcomments.json
+++ b/Tests/JayTests/Fixtures/withcomments.json
@@ -1,0 +1,12 @@
+{
+    "message": "Hello world.", // single line comments work
+    "other": "/* don't strip this out */",
+    /* 
+
+    but do strip this out!
+    yeah all of this
+
+    */
+    "crazy": "\"/*wow escaped strings are*/ // annoying looking \"",
+    "number": 3
+}

--- a/Tests/JayTests/ParsingTests.swift
+++ b/Tests/JayTests/ParsingTests.swift
@@ -20,6 +20,11 @@ extension ParsingTests {
         ("testBoolean_True_Mismatch", testBoolean_True_Mismatch),
         ("testBoolean_False_Normal", testBoolean_False_Normal),
         ("testBoolean_False_Mismatch", testBoolean_False_Mismatch),
+        ("testComment_SingleLine_EndedWithNewline", testComment_SingleLine_EndedWithNewline),
+        ("testComment_SingleLine_EndedReader", testComment_SingleLine_EndedReader),
+        ("testComment_MultiLine_ActuallySingleLine", testComment_MultiLine_ActuallySingleLine),
+        ("testComment_MultiLine_ThreeLines", testComment_MultiLine_ThreeLines),
+        ("testAllIncludingComment_FromFile", testAllIncludingComment_FromFile),
         ("testArray_NullsBoolsNums_Normal_Minimal_RootParser", testArray_NullsBoolsNums_Normal_Minimal_RootParser),
         ("testArray_NullsBoolsNums_Normal_MuchWhitespace", testArray_NullsBoolsNums_Normal_MuchWhitespace),
         ("testArray_NullsAndBooleans_Bad_MissingEnd", testArray_NullsAndBooleans_Bad_MissingEnd),
@@ -96,7 +101,6 @@ class ParsingTests:XCTestCase {
         XCTAssertNil(ret)
     }
     
-    //TODO: add names to linux manifest
     func testComment_SingleLine_EndedWithNewline() throws {
         
         let reader = ByteReader(content: "// hello world \n")

--- a/Tests/JayTests/PerformanceTests.swift
+++ b/Tests/JayTests/PerformanceTests.swift
@@ -17,30 +17,31 @@ extension PerformanceTests {
     ]
 }
 
+func urlForFixture(_ name: String) -> URL {
+    
+    let parent = (#file).components(separatedBy: "/").dropLast().joined(separator: "/")
+    let url = URL(string: "file://\(parent)/Fixtures/\(name).json")!
+    print("Loading fixture from url \(url)")
+    return url
+}
+
+func loadFixture(_ name: String) -> [UInt8] {
+    let data = Array(try! loadFixtureData(name))
+    return data
+}
+
+func loadFixtureData(_ name: String) throws -> Data {
+    let url = urlForFixture(name)
+    let data = try Data(contentsOf: url)
+    return data
+}
+
 class PerformanceTests: XCTestCase {
 
-    func urlForFixture(_ name: String) -> URL {
-        
-        let parent = (#file).components(separatedBy: "/").dropLast().joined(separator: "/")
-        let url = URL(string: "file://\(parent)/Fixtures/\(name).json")!
-        print("Loading fixture from url \(url)")
-        return url
-    }
     
-    func loadFixture(_ name: String) -> [UInt8] {
-        let data = Array(try! loadFixtureData(name))
-        return data
-    }
-    
-    func loadFixtureData(_ name: String) throws -> Data {
-        let url = self.urlForFixture(name)
-        let data = try Data(contentsOf: url)
-        return data
-    }
-
     func testPerf_ParseLargeJson() {
         
-        let data = self.loadFixture("large")
+        let data = loadFixture("large")
         let jay = Jay()
         measure {
             do {

--- a/Tests/JayTests/TestUtils.swift
+++ b/Tests/JayTests/TestUtils.swift
@@ -32,6 +32,10 @@ func ensureNull(_ val: JSON) {
     XCTAssertEqual(val, JSON.null)
 }
 
+func ensureComment(_ val: [JChar], exp: String, file: StaticString = #file, line: UInt = #line) throws {
+    XCTAssertEqual(try val.string(), exp)
+}
+
 func ensureBool(_ val: JSON, exp: Bool, file: StaticString = #file, line: UInt = #line) {
     XCTAssertEqual(val, JSON.boolean(exp))
 }

--- a/Tests/JayTests/TestUtils.swift
+++ b/Tests/JayTests/TestUtils.swift
@@ -69,6 +69,31 @@ func ensureObject(_ val: JSON, exp: [String: JSON], file: StaticString = #file, 
     XCTAssertEqual(val, JSON.object(exp))
 }
 
+extension StringParser {
+    init() {
+        self = StringParser(parsing: .none)
+    }
+}
+
+extension ValueParser {
+    init() {
+        self = ValueParser(parsing: .none)
+    }
+}
+
+extension RootParser {
+    init() {
+        self = RootParser(parsing: .none)
+    }
+}
+
+extension Parser {
+    init() {
+        self = Parser(parsing: .none)
+    }
+}
+
+
 //
 //  Conversions.swift
 //  Jay


### PR DESCRIPTION
Fixes #43. /cc @tannernelson

Funny thing, the easiest way to do it was to treat comments as a new type of token that we're trying to parse. This means I actually pull all those comments out before throwing them away. Means that if we found a nice API to emit found comments, that would be very easy to do. (But I don't think that's really useful, just a fun fact)
