### PR TITLE
Properly escape all control chars when formatting

### DIFF
--- a/Sources/Jay/Consts.swift
+++ b/Sources/Jay/Consts.swift
@@ -51,7 +51,9 @@ struct Const {
         Const.FormFeed: Const.FormFeedChar,
         Const.CarriageReturn: Const.CarriageReturnChar
     ]
-
+    
+    static let ControlCharacters: Set<JChar> = Set(0x00...0x1f)
+    
     // Strings
     static let QuotationMark: JChar         = 0x22 // """
     static let ReverseSolidus: JChar        = 0x5c // "\"
@@ -66,7 +68,7 @@ struct Const {
     
     static let UnicodeStart: JChar          = 0x75 // "u"
 
-    static let Escape: JChar            = Const.ReverseSolidus
+    static let Escape: JChar                = Const.ReverseSolidus
 
     static let SimpleEscaped: Set<JChar> = [
         Const.QuotationMark,

--- a/Sources/Jay/Extensions.swift
+++ b/Sources/Jay/Extensions.swift
@@ -21,6 +21,22 @@ extension JChar {
     }
 }
 
+extension JChar {
+    
+    func controlCharacterHexString() -> [JChar] {
+        var hex = String(self, radix: 16, uppercase: false).chars()
+        
+        //control chars are always only two hex characters, so we either got 1 or 2 chars,
+        //pad to two
+        if hex.count == 1 {
+            hex = [Const.Zero] + hex
+        }
+        
+        //and prepend with \u00, which is followed by our two hex bytes
+        return [Const.Escape, Const.UnicodeStart, Const.Zero, Const.Zero] + hex
+    }
+}
+
 extension String {
     
     func chars() -> [JChar] {

--- a/Sources/Jay/Formatter.swift
+++ b/Sources/Jay/Formatter.swift
@@ -50,7 +50,7 @@ extension JSON: JsonFormattable {
     
     func format(to stream: JsonOutputStream, string: String) throws {
         
-        var contents = [JChar]()
+        var contents: [JChar] = []
         for c in string.utf8 {
             
             //if this is an escapable character, escape it
@@ -63,6 +63,13 @@ extension JSON: JsonFormattable {
             //simple escape, just prepend with the escape char
             if Const.SimpleEscaped.contains(c) {
                 contents.append(contentsOf: [Const.Escape, c])
+                continue
+            }
+            
+            //control character that wasn't escaped above, just convert to 
+            //an escaped unicode sequence, i.e. "\u0006" for "ACK"
+            if Const.ControlCharacters.contains(c) {
+                contents.append(contentsOf: c.controlCharacterHexString())
                 continue
             }
             

--- a/Tests/JayTests/FormattingTests.swift
+++ b/Tests/JayTests/FormattingTests.swift
@@ -155,9 +155,10 @@ class FormattingTests: XCTestCase {
     }
 
     func testString_Escaping() {
-        let json = ["he \r\n l \t l \n o w\"o\rrld "]
+        let json = ["he \r\n l \u{0006} \t l \n o w\"o\rrld \u{0015} "]
         let data = try! Jay().dataFromJson(any: json)
-        XCTAssertEqual(data, "[\"he \\r\\n l \\t l \\n o w\\\"o\\rrld \"]".chars())
+        let res = "[\"he \\r\\n l \\u0006 \\t l \\n o w\\\"o\\rrld \\u0015 \"]".chars()
+        XCTAssertEqual(data, res)
     }
     
     func testVaporExample_Dict() {


### PR DESCRIPTION
Fixes #45. /cc Thanks to @vdka for pointing out it was missing! 🎉 
