### PR TITLE
remove examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ script:
   - swift build
   - swift build -c release
   - swift test
-  - ./.build/release/JayPerformance
 notifications:
   email:
     on_success: never

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,11 @@ import PackageDescription
 let package = Package(
     name: "Jay",
     targets: [
-        Target(name: "JayExample", dependencies: ["Jay"]),
-        Target(name: "JayPerformance", dependencies: ["Jay"])
+        // Target(name: "JayExample", dependencies: ["Jay"]),
+        // Target(name: "JayPerformance", dependencies: ["Jay"])
+    ],
+    exclude: [
+        "Sources/JayExample",
+        "Sources/JayPerformance",
     ]
 )


### PR DESCRIPTION
Example projects clutter the `swift build` output, increase the duration of build times, and complicate integration with other platforms like iOS.

We've asked the SwiftPM team for ways to make examples "public" or "private", but it looks like such features won't be available for the foreseeable future. 

Until then, those wanting to test out the examples can simply clone Jay and uncomment the Target in the Package. 
